### PR TITLE
Add REST API crate powered by Poem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,12 +28,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -51,7 +105,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -62,7 +116,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -80,7 +134,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "bitflags 1.3.2",
- "bytes",
+ "bytes 1.10.1",
  "futures-util",
  "http",
  "http-body",
@@ -106,7 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.10.1",
  "futures-util",
  "http",
  "http-body",
@@ -133,6 +187,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -150,10 +210,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -162,10 +253,167 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "aes-gcm",
+ "base64 0.21.7",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand",
+ "sha2",
+ "subtle",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -190,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,12 +456,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -215,6 +494,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "futures-sink"
@@ -234,10 +541,38 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures",
+ "memchr",
+ "pin-project 0.4.30",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -264,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +620,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -301,10 +646,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.10.1",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -312,7 +699,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "fnv",
  "itoa",
 ]
@@ -323,7 +710,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "http",
  "pin-project-lite",
 ]
@@ -346,7 +733,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -377,6 +764,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +811,15 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -423,6 +849,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +875,16 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -479,10 +931,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes 1.10.1",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "tokio",
+ "version_check",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -498,6 +995,35 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -517,11 +1043,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.10",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -532,7 +1078,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -546,6 +1092,115 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poem"
+version = "1.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
+dependencies = [
+ "async-trait",
+ "bytes 1.10.1",
+ "chrono",
+ "cookie",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "mime",
+ "multer",
+ "nix",
+ "parking_lot",
+ "percent-encoding",
+ "pin-project-lite",
+ "poem-derive",
+ "regex",
+ "rfc7239",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "sse-codec",
+ "tempfile",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
+name = "poem-derive"
+version = "1.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
+dependencies = [
+ "proc-macro-crate 2.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "poem-openapi"
+version = "1.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234d06e44e67006381bf9b9094ad0feeac3d2fea5d515bac9f59a21817c5150a"
+dependencies = [
+ "base64 0.13.1",
+ "bytes 1.10.1",
+ "derive_more",
+ "futures-util",
+ "mime",
+ "num-traits",
+ "poem",
+ "poem-openapi-derive",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "poem-openapi-derive"
+version = "1.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266910362564aade035a0b871c23e283c2a28fba74e7e7d10f2f0dffe0453a14"
+dependencies = [
+ "Inflector",
+ "darling",
+ "http",
+ "indexmap 1.9.3",
+ "mime",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -563,7 +1218,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -581,7 +1255,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "prost-derive",
 ]
 
@@ -591,7 +1265,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "heck",
  "itertools",
  "log",
@@ -602,7 +1276,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.106",
  "tempfile",
 ]
 
@@ -616,7 +1290,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -684,6 +1358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,10 +1396,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rest_api"
+version = "0.1.0"
+dependencies = [
+ "poem",
+ "poem-openapi",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "rfc7239"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a82f1d1e38e9a85bb58ffcfadf22ed6f2c94e8cd8581ec2b0f80a2a6858350f"
+dependencies = [
+ "uncased",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -738,12 +1450,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -763,14 +1494,73 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -790,6 +1580,47 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sse-codec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a59f811350c44b4a037aabeb72dc6a9591fc22aa95a036db9a96297c58085a"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-io",
+ "futures_codec",
+ "memchr",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -823,13 +1654,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
- "bytes",
+ "bytes 1.10.1",
  "io-uring",
  "libc",
  "mio",
@@ -858,7 +1740,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -878,11 +1760,40 @@ version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
- "bytes",
+ "bytes 1.10.1",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.11.4",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.11.4",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -894,15 +1805,15 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
- "bytes",
+ "base64 0.21.7",
+ "bytes 1.10.1",
  "h2",
  "http",
  "http-body",
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.1.10",
  "prost",
  "tokio",
  "tokio-stream",
@@ -922,7 +1833,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -946,7 +1857,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project",
+ "pin-project 1.1.10",
  "pin-project-lite",
  "rand",
  "slab",
@@ -988,7 +1899,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1007,10 +1918,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1046,10 +1988,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wildmatch"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b7d07a236abaef6607536ccfaf19b396dbe3f5110ddb73d39f4562902ed382"
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1143,6 +2203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,5 +2234,5 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "proto_gen",
+    "rest_api",
     "tonic_server",
 ]
 resolver = "2"

--- a/rest_api/Cargo.toml
+++ b/rest_api/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rest_api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+poem = { version = "1.3", features = ["test"] }
+poem-openapi = { version = "1.3", features = ["swagger-ui"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -1,0 +1,5 @@
+# rest_api
+
+This crate hosts a Poem based REST API that exposes an echo route and a
+telemetry ingestion route. The API publishes an OpenAPI specification and
+includes unit tests demonstrating the primary interactions.

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -1,5 +1,12 @@
 # rest_api
 
-This crate hosts a Poem based REST API that exposes an echo route and a
-telemetry ingestion route. The API publishes an OpenAPI specification and
-includes unit tests demonstrating the primary interactions.
+This crate hosts a Poem based REST API that exposes:
+
+* A login route that returns a mock bearer token for subsequent requests.
+* An echo route that reflects the payload back to the caller when the bearer
+  token is supplied.
+* A telemetry ingestion route that parses structured JSON telemetry and returns
+  the parsed representation when authorized.
+
+The API publishes an OpenAPI specification and includes unit tests
+demonstrating the primary interactions.

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -1,0 +1,154 @@
+//! REST API binary for the Vibes workspace.
+//!
+//! The binary exposes a Poem web server that publishes an OpenAPI
+//! specification and implements two endpoints: an echo endpoint and a
+//! telemetry ingestion endpoint.
+
+use poem::{Error, Result as PoemResult, Route, Server, http::StatusCode, listener::TcpListener};
+use poem_openapi::payload::Json;
+use poem_openapi::{Object, OpenApi, OpenApiService};
+use serde::{Deserialize, Serialize};
+
+/// Payload accepted and returned by the echo endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+struct EchoPayload {
+    /// The text that will be echoed back in the response.
+    message: String,
+}
+
+/// Structured data that can be deserialized from a JSON string by the
+/// telemetry ingestion endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+struct TelemetryRecord {
+    /// A human readable message supplied by the caller.
+    message: String,
+    /// An integer value associated with the telemetry payload.
+    count: i32,
+    /// A floating point measurement associated with the payload.
+    ratio: f64,
+}
+
+/// Collection of OpenAPI endpoints exposed by the REST API server.
+struct Api;
+
+#[OpenApi]
+impl Api {
+    /// Echoes a JSON payload back to the caller without any modification.
+    #[oai(path = "/echo", method = "post")]
+    async fn echo(&self, payload: Json<EchoPayload>) -> Json<EchoPayload> {
+        Json(payload.0)
+    }
+
+    /// Accepts a JSON string, parses it into a [`TelemetryRecord`], logs the
+    /// content, and returns the structured representation.
+    #[oai(path = "/ingest", method = "post")]
+    async fn ingest(&self, payload: Json<String>) -> PoemResult<Json<TelemetryRecord>> {
+        let record: TelemetryRecord = serde_json::from_str(&payload.0).map_err(|error| {
+            Error::from_string(
+                format!("Invalid JSON payload: {error}"),
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        println!(
+            "Received telemetry record: message='{}', count={}, ratio={}",
+            record.message, record.count, record.ratio
+        );
+
+        Ok(Json(record))
+    }
+}
+
+/// Builds the Poem application with the OpenAPI service and documentation
+/// routes.
+fn create_app() -> Route {
+    let api_service =
+        OpenApiService::new(Api, "Vibes REST API", "1.0").server("http://localhost:3000/api");
+    let ui = api_service.swagger_ui();
+    let spec = api_service.spec_endpoint();
+
+    Route::new()
+        .nest("/api", api_service)
+        .nest("/docs", ui)
+        .at("/openapi.json", spec)
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let app = create_app();
+
+    Server::new(TcpListener::bind("0.0.0.0:3000"))
+        .name("vibes-rest-api")
+        .run(app)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poem::http::StatusCode;
+    use poem::test::TestClient;
+    use serde_json::json;
+
+    /// Ensures the echo route mirrors the input payload.
+    #[tokio::test]
+    async fn echo_round_trips_payload() {
+        let client = TestClient::new(create_app());
+        let payload = EchoPayload {
+            message: String::from("Hello, Vibes!"),
+        };
+
+        let response = client.post("/api/echo").body_json(&payload).send().await;
+
+        response.assert_status_is_ok();
+        response.assert_json(&payload).await;
+    }
+
+    /// Ensures the ingestion route parses a JSON string and returns the
+    /// structured telemetry data.
+    #[tokio::test]
+    async fn ingest_parses_json_string() {
+        let client = TestClient::new(create_app());
+        let telemetry_json = json!({
+            "message": "Temperature reading",
+            "count": 3,
+            "ratio": 0.618
+        })
+        .to_string();
+
+        let response = client
+            .post("/api/ingest")
+            .body_json(&telemetry_json)
+            .send()
+            .await;
+
+        response.assert_status_is_ok();
+        let json_body = response.json().await;
+        let parsed: TelemetryRecord = json_body.value().deserialize();
+
+        assert_eq!(parsed.message, "Temperature reading");
+        assert_eq!(parsed.count, 3);
+        assert!((parsed.ratio - 0.618).abs() < f64::EPSILON);
+    }
+
+    /// Validates that invalid JSON strings produce a bad request error.
+    #[tokio::test]
+    async fn ingest_rejects_invalid_json() {
+        let client = TestClient::new(create_app());
+
+        let response = client
+            .post("/api/ingest")
+            .body_json(&"not-json".to_string())
+            .send()
+            .await;
+
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body = response
+            .0
+            .into_body()
+            .into_string()
+            .await
+            .expect("body should be readable");
+        assert!(body.contains("Invalid JSON payload"));
+    }
+}

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -4,7 +4,7 @@
 //! specification and implements two endpoints: an echo endpoint and a
 //! telemetry ingestion endpoint.
 
-use poem::{Error, Result as PoemResult, Route, Server, http::StatusCode, listener::TcpListener};
+use poem::{Route, Server, listener::TcpListener};
 use poem_openapi::payload::Json;
 use poem_openapi::{Object, OpenApi, OpenApiService};
 use serde::{Deserialize, Serialize};
@@ -39,23 +39,18 @@ impl Api {
         Json(payload.0)
     }
 
-    /// Accepts a JSON string, parses it into a [`TelemetryRecord`], logs the
+    /// Accepts a JSON payload that represents a [`TelemetryRecord`], logs the
     /// content, and returns the structured representation.
     #[oai(path = "/ingest", method = "post")]
-    async fn ingest(&self, payload: Json<String>) -> PoemResult<Json<TelemetryRecord>> {
-        let record: TelemetryRecord = serde_json::from_str(&payload.0).map_err(|error| {
-            Error::from_string(
-                format!("Invalid JSON payload: {error}"),
-                StatusCode::BAD_REQUEST,
-            )
-        })?;
+    async fn ingest(&self, payload: Json<TelemetryRecord>) -> Json<TelemetryRecord> {
+        let record = payload.0;
 
         println!(
             "Received telemetry record: message='{}', count={}, ratio={}",
             record.message, record.count, record.ratio
         );
 
-        Ok(Json(record))
+        Json(record)
     }
 }
 
@@ -104,21 +99,20 @@ mod tests {
         response.assert_json(&payload).await;
     }
 
-    /// Ensures the ingestion route parses a JSON string and returns the
+    /// Ensures the ingestion route parses a JSON payload and returns the
     /// structured telemetry data.
     #[tokio::test]
-    async fn ingest_parses_json_string() {
+    async fn ingest_parses_json_payload() {
         let client = TestClient::new(create_app());
-        let telemetry_json = json!({
-            "message": "Temperature reading",
-            "count": 3,
-            "ratio": 0.618
-        })
-        .to_string();
+        let telemetry_record = TelemetryRecord {
+            message: String::from("Temperature reading"),
+            count: 3,
+            ratio: 0.618,
+        };
 
         let response = client
             .post("/api/ingest")
-            .body_json(&telemetry_json)
+            .body_json(&telemetry_record)
             .send()
             .await;
 
@@ -131,14 +125,16 @@ mod tests {
         assert!((parsed.ratio - 0.618).abs() < f64::EPSILON);
     }
 
-    /// Validates that invalid JSON strings produce a bad request error.
+    /// Validates that invalid JSON payloads produce a bad request error.
     #[tokio::test]
     async fn ingest_rejects_invalid_json() {
         let client = TestClient::new(create_app());
 
         let response = client
             .post("/api/ingest")
-            .body_json(&"not-json".to_string())
+            .body_json(&json!({
+                "message": "missing fields",
+            }))
             .send()
             .await;
 
@@ -149,6 +145,6 @@ mod tests {
             .into_string()
             .await
             .expect("body should be readable");
-        assert!(body.contains("Invalid JSON payload"));
+        assert!(!body.is_empty(), "error response should include a message");
     }
 }

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -1,19 +1,51 @@
 //! REST API binary for the Vibes workspace.
 //!
 //! The binary exposes a Poem web server that publishes an OpenAPI
-//! specification and implements two endpoints: an echo endpoint and a
-//! telemetry ingestion endpoint.
+//! specification and implements three endpoints: a login endpoint, an echo
+//! endpoint, and a telemetry ingestion endpoint. The login endpoint returns a
+//! mock bearer token that must be supplied to access the other routes.
 
-use poem::{Route, Server, listener::TcpListener};
+use poem::{Error, Result, Route, Server, http::StatusCode, listener::TcpListener};
+use poem_openapi::auth::Bearer;
 use poem_openapi::payload::Json;
-use poem_openapi::{Object, OpenApi, OpenApiService};
+use poem_openapi::{Object, OpenApi, OpenApiService, SecurityScheme};
 use serde::{Deserialize, Serialize};
+
+/// Mock bearer token returned by the login endpoint and required to access the
+/// protected routes. In a production system this would be generated dynamically
+/// and validated through a persistence layer, but the constant keeps the fixture
+/// simple for testing.
+const MOCK_BEARER_TOKEN: &str = "vibes-mock-bearer-token";
+
+/// Security scheme wrapper for the bearer token required by the protected
+/// routes. This leverages Poem OpenAPI's [`SecurityScheme`] derive to document
+/// the requirement in the generated specification.
+#[derive(SecurityScheme)]
+#[oai(type = "bearer")]
+struct MockTokenAuth(Bearer);
 
 /// Payload accepted and returned by the echo endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize, Object)]
 struct EchoPayload {
     /// The text that will be echoed back in the response.
     message: String,
+}
+
+/// Payload accepted by the login endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+struct LoginRequest {
+    /// Username supplied by the caller.
+    username: String,
+    /// Password supplied by the caller.
+    password: String,
+}
+
+/// Response returned by the login endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+struct LoginResponse {
+    /// Mock bearer token that must be provided when interacting with the
+    /// protected routes.
+    token: String,
 }
 
 /// Structured data that can be deserialized from a JSON string by the
@@ -33,16 +65,39 @@ struct Api;
 
 #[OpenApi]
 impl Api {
+    /// Issues a mock bearer token that can be used to access the protected
+    /// routes. This endpoint does not validate the supplied credentials because
+    /// the API acts as a test fixture.
+    #[oai(path = "/login", method = "post")]
+    async fn login(&self, payload: Json<LoginRequest>) -> Json<LoginResponse> {
+        let _ = payload;
+
+        Json(LoginResponse {
+            token: MOCK_BEARER_TOKEN.to_string(),
+        })
+    }
+
     /// Echoes a JSON payload back to the caller without any modification.
     #[oai(path = "/echo", method = "post")]
-    async fn echo(&self, payload: Json<EchoPayload>) -> Json<EchoPayload> {
-        Json(payload.0)
+    async fn echo(
+        &self,
+        auth: MockTokenAuth,
+        payload: Json<EchoPayload>,
+    ) -> Result<Json<EchoPayload>> {
+        authorize(&auth)?;
+
+        Ok(Json(payload.0))
     }
 
     /// Accepts a JSON payload that represents a [`TelemetryRecord`], logs the
     /// content, and returns the structured representation.
     #[oai(path = "/ingest", method = "post")]
-    async fn ingest(&self, payload: Json<TelemetryRecord>) -> Json<TelemetryRecord> {
+    async fn ingest(
+        &self,
+        auth: MockTokenAuth,
+        payload: Json<TelemetryRecord>,
+    ) -> Result<Json<TelemetryRecord>> {
+        authorize(&auth)?;
         let record = payload.0;
 
         println!(
@@ -50,7 +105,18 @@ impl Api {
             record.message, record.count, record.ratio
         );
 
-        Json(record)
+        Ok(Json(record))
+    }
+}
+
+/// Validates that the supplied bearer token matches the mock token returned by
+/// the login endpoint. Returns an unauthorized error when the token is missing
+/// or invalid.
+fn authorize(auth: &MockTokenAuth) -> Result<()> {
+    if auth.0.token == MOCK_BEARER_TOKEN {
+        Ok(())
+    } else {
+        Err(Error::from_status(StatusCode::UNAUTHORIZED))
     }
 }
 
@@ -81,13 +147,70 @@ async fn main() -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use poem::http::StatusCode;
     use poem::test::TestClient;
+    use poem::{Endpoint, http::StatusCode};
     use serde_json::json;
+
+    /// Helper that logs in and retrieves the mock bearer token.
+    async fn login<E: Endpoint>(client: &TestClient<E>) -> String {
+        let response = client
+            .post("/api/login")
+            .body_json(&LoginRequest {
+                username: String::from("user"),
+                password: String::from("pass"),
+            })
+            .send()
+            .await;
+
+        response.assert_status_is_ok();
+        let token_response: LoginResponse = response.json().await.value().deserialize();
+
+        token_response.token
+    }
+
+    /// Ensures the login route returns the mock bearer token.
+    #[tokio::test]
+    async fn login_returns_mock_token() {
+        let client = TestClient::new(create_app());
+        let response = client
+            .post("/api/login")
+            .body_json(&LoginRequest {
+                username: String::from("demo"),
+                password: String::from("secret"),
+            })
+            .send()
+            .await;
+
+        response.assert_status_is_ok();
+        let body = response.json().await;
+        let token: LoginResponse = body.value().deserialize();
+
+        assert_eq!(token.token, MOCK_BEARER_TOKEN);
+    }
 
     /// Ensures the echo route mirrors the input payload.
     #[tokio::test]
     async fn echo_round_trips_payload() {
+        let client = TestClient::new(create_app());
+        let token = login(&client).await;
+        let payload = EchoPayload {
+            message: String::from("Hello, Vibes!"),
+        };
+
+        let response = client
+            .post("/api/echo")
+            .header("Authorization", format!("Bearer {}", token))
+            .body_json(&payload)
+            .send()
+            .await;
+
+        response.assert_status_is_ok();
+        response.assert_json(&payload).await;
+    }
+
+    /// Ensures the echo route rejects requests without the bearer token.
+    #[tokio::test]
+    async fn echo_requires_token() {
         let client = TestClient::new(create_app());
         let payload = EchoPayload {
             message: String::from("Hello, Vibes!"),
@@ -95,8 +218,25 @@ mod tests {
 
         let response = client.post("/api/echo").body_json(&payload).send().await;
 
-        response.assert_status_is_ok();
-        response.assert_json(&payload).await;
+        response.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    /// Ensures the echo route rejects requests with an invalid bearer token.
+    #[tokio::test]
+    async fn echo_rejects_invalid_token() {
+        let client = TestClient::new(create_app());
+        let payload = EchoPayload {
+            message: String::from("Hello, Vibes!"),
+        };
+
+        let response = client
+            .post("/api/echo")
+            .header("Authorization", "Bearer wrong-token")
+            .body_json(&payload)
+            .send()
+            .await;
+
+        response.assert_status(StatusCode::UNAUTHORIZED);
     }
 
     /// Ensures the ingestion route parses a JSON payload and returns the
@@ -104,6 +244,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_parses_json_payload() {
         let client = TestClient::new(create_app());
+        let token = login(&client).await;
         let telemetry_record = TelemetryRecord {
             message: String::from("Temperature reading"),
             count: 3,
@@ -112,6 +253,7 @@ mod tests {
 
         let response = client
             .post("/api/ingest")
+            .header("Authorization", format!("Bearer {}", token))
             .body_json(&telemetry_record)
             .send()
             .await;
@@ -129,9 +271,11 @@ mod tests {
     #[tokio::test]
     async fn ingest_rejects_invalid_json() {
         let client = TestClient::new(create_app());
+        let token = login(&client).await;
 
         let response = client
             .post("/api/ingest")
+            .header("Authorization", format!("Bearer {}", token))
             .body_json(&json!({
                 "message": "missing fields",
             }))
@@ -146,5 +290,25 @@ mod tests {
             .await
             .expect("body should be readable");
         assert!(!body.is_empty(), "error response should include a message");
+    }
+
+    /// Ensures the ingestion route rejects requests when the bearer token is
+    /// missing.
+    #[tokio::test]
+    async fn ingest_requires_token() {
+        let client = TestClient::new(create_app());
+        let telemetry_record = TelemetryRecord {
+            message: String::from("Temperature reading"),
+            count: 3,
+            ratio: 0.618,
+        };
+
+        let response = client
+            .post("/api/ingest")
+            .body_json(&telemetry_record)
+            .send()
+            .await;
+
+        response.assert_status(StatusCode::UNAUTHORIZED);
     }
 }

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -17,11 +17,12 @@ use serde::{Deserialize, Serialize};
 /// simple for testing.
 const MOCK_BEARER_TOKEN: &str = "vibes-mock-bearer-token";
 
-/// Security scheme wrapper for the bearer token required by the protected
-/// routes. This leverages Poem OpenAPI's [`SecurityScheme`] derive to document
-/// the requirement in the generated specification.
+/// Security scheme wrapper for the `Authorization: Bearer` header required by
+/// the protected routes. This leverages Poem OpenAPI's [`SecurityScheme`]
+/// derive to document the requirement in the generated specification and
+/// exposes a Swagger "Authorize" control through the renamed scheme.
 #[derive(SecurityScheme)]
-#[oai(type = "bearer")]
+#[oai(type = "bearer", bearer_format = "Mock fixture token", rename = "BearerAuth")]
 struct MockTokenAuth(Bearer);
 
 /// Payload accepted and returned by the echo endpoint.
@@ -149,7 +150,7 @@ mod tests {
     use super::*;
     use poem::test::TestClient;
     use poem::{Endpoint, http::StatusCode};
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     /// Helper that logs in and retrieves the mock bearer token.
     async fn login<E: Endpoint>(client: &TestClient<E>) -> String {
@@ -310,5 +311,24 @@ mod tests {
             .await;
 
         response.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    /// Ensures the generated OpenAPI specification documents the bearer token
+    /// security scheme on the protected routes while leaving the login route
+    /// unauthenticated.
+    #[test]
+    fn openapi_spec_lists_bearer_token_requirement() {
+        let service = OpenApiService::new(Api, "Vibes REST API", "1.0");
+        let spec: Value = serde_json::from_str(&service.spec()).expect("valid OpenAPI spec");
+
+        let echo_security = spec["paths"]["/echo"]["post"]["security"].as_array().expect("echo security entries");
+        assert!(echo_security.iter().any(|entry| entry.get("BearerAuth").is_some()));
+
+        let ingest_security = spec["paths"]["/ingest"]["post"]["security"].as_array().expect("ingest security entries");
+        assert!(ingest_security.iter().any(|entry| entry.get("BearerAuth").is_some()));
+
+        assert!(spec["paths"]["/login"]["post"]["security"].is_null());
+
+        assert!(spec["components"]["securitySchemes"]["BearerAuth"].is_object());
     }
 }


### PR DESCRIPTION
## Summary
- add a new `rest_api` crate that serves Poem routes with OpenAPI support
- implement echo and JSON ingestion endpoints with structured logging and unit tests
- wire the crate into the workspace configuration

## Testing
- cargo test
- cargo test -p rest_api

------
https://chatgpt.com/codex/tasks/task_e_68db3d51a81c8332816f1862fdb8df45